### PR TITLE
fix: replace StructService constructor injection with CapConnection

### DIFF
--- a/studio-server/pom.xml
+++ b/studio-server/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>cap-unified-api</artifactId>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>com.coremedia.cms</groupId>
+          <artifactId>common.beans-for-plugins</artifactId>
+          <!-- scope: compile is necessary-->
+      </dependency>
     <dependency>
     <groupId>org.springframework</groupId>
     <artifactId>spring-core</artifactId>

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/bynder/BynderContentHubAdapter.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/bynder/BynderContentHubAdapter.java
@@ -1,5 +1,6 @@
 package com.coremedia.labs.plugins.adapters.bynder;
 
+import com.coremedia.cap.common.CapConnection;
 import com.coremedia.cap.struct.StructService;
 import com.coremedia.contenthub.api.*;
 import com.coremedia.contenthub.api.column.ColumnProvider;
@@ -43,10 +44,10 @@ public class BynderContentHubAdapter implements ContentHubAdapter, ContentHubSea
   private final StructService structService;
   private final BynderContentHubSettings bynderContentHubSettings;
 
-  public BynderContentHubAdapter(BynderContentHubSettings settings, String connectionId, MimeTypeService mimeTypeService, StructService structService) {
+  public BynderContentHubAdapter(BynderContentHubSettings settings, String connectionId, MimeTypeService mimeTypeService, CapConnection connection) {
     this.connectionId = connectionId;
     this.mimeTypeService = mimeTypeService;
-    this.structService = structService;
+    this.structService = connection.getStructService();
     this.bynderContentHubSettings = settings;
 
     // base folders

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/bynder/BynderContentHubAdapterFactory.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/bynder/BynderContentHubAdapterFactory.java
@@ -1,5 +1,6 @@
 package com.coremedia.labs.plugins.adapters.bynder;
 
+import com.coremedia.cap.common.CapConnection;
 import com.coremedia.cap.struct.StructService;
 import com.coremedia.contenthub.api.ContentHubAdapter;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
@@ -13,11 +14,11 @@ public class BynderContentHubAdapterFactory implements ContentHubAdapterFactory<
   private static final String ADAPTER_ID = "bynder";
 
   private final MimeTypeService mimeTypeService;
-  private final StructService structService;
+  private final CapConnection connection;
 
-  public BynderContentHubAdapterFactory(@NonNull MimeTypeService mimeTypeService, @NonNull StructService structService) {
+  public BynderContentHubAdapterFactory(@NonNull MimeTypeService mimeTypeService, @NonNull CapConnection connection) {
     this.mimeTypeService = mimeTypeService;
-    this.structService = structService;
+    this.connection = connection;
   }
 
   @Override
@@ -28,6 +29,6 @@ public class BynderContentHubAdapterFactory implements ContentHubAdapterFactory<
   @Override
   public ContentHubAdapter createAdapter(@NonNull BynderContentHubSettings settings,
                                          @NonNull String connectionId) {
-    return new BynderContentHubAdapter(settings, connectionId, mimeTypeService, structService);
+    return new BynderContentHubAdapter(settings, connectionId, mimeTypeService, connection);
   }
 }

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/bynder/configuration/BynderContentHubAdapterConfiguration.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/bynder/configuration/BynderContentHubAdapterConfiguration.java
@@ -1,6 +1,6 @@
 package com.coremedia.labs.plugins.adapters.bynder.configuration;
 
-import com.coremedia.cap.struct.StructService;
+import com.coremedia.cap.common.CapConnection;
 import com.coremedia.labs.plugins.adapters.bynder.BynderContentHubAdapterFactory;
 import com.coremedia.labs.plugins.adapters.bynder.BynderContentHubSettings;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
@@ -9,13 +9,14 @@ import com.coremedia.mimetype.MimeTypeServiceConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import com.coremedia.cms.common.plugins.beans_for_plugins.CommonBeansForPluginsConfiguration;
 
 @Configuration
-@Import(MimeTypeServiceConfiguration.class)
+@Import({MimeTypeServiceConfiguration.class, CommonBeansForPluginsConfiguration.class})
 public class BynderContentHubAdapterConfiguration {
 
   @Bean
-  public ContentHubAdapterFactory<BynderContentHubSettings> bynderContentHubAdapterFactory(MimeTypeService mimeTypeService, StructService structService) {
-    return new BynderContentHubAdapterFactory(mimeTypeService, structService);
+  public ContentHubAdapterFactory<BynderContentHubSettings> bynderContentHubAdapterFactory(MimeTypeService mimeTypeService, CapConnection connection) {
+    return new BynderContentHubAdapterFactory(mimeTypeService, connection);
   }
 }


### PR DESCRIPTION
- Remove StructService from constructor as it's unavailable in plugin context
- Use CapConnection to retrieve StructService instead
- Ensures proper service access within plugin environment